### PR TITLE
Enum Variant Titles

### DIFF
--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -29,7 +29,7 @@ fn gen_struct(name: Option<&LitStr>, fields: &[ParseDataField]) -> TokenStream {
 	let option = path!(::core::option::Option);
 
 	let name = match name {
-		Some(name) => quote!(#option::Some(#name)),
+		Some(name) => quote!(#option::Some(::std::string::String::from(#name))),
 		None => quote!(#option::None)
 	};
 
@@ -109,7 +109,7 @@ fn gen_struct(name: Option<&LitStr>, fields: &[ParseDataField]) -> TokenStream {
 					)
 				)
 			);
-			schema.name = #name.map(|name: &::core::primitive::str| ::std::string::String::from(name));
+			schema.name = #name;
 			schema
 		}
 	}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -102,7 +102,7 @@ fn expand_openapi_type(mut input: DeriveInput) -> syn::Result<TokenStream2> {
 				const NAME: &::core::primitive::str = #name;
 				schema.name = ::std::option::Option::Some(::std::string::String::from(NAME));
 
-				const DESCRIPTION: ::core::option::Option<&'static core::primitive::str> = #doc;
+				const DESCRIPTION: ::core::option::Option<&'static ::core::primitive::str> = #doc;
 				schema.description = DESCRIPTION.map(|desc| ::std::string::String::from(desc));
 
 				schema

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -79,8 +79,8 @@ fn expand_openapi_type(mut input: DeriveInput) -> syn::Result<TokenStream2> {
 
 	// parse the input data
 	let parsed = match &input.data {
-		Data::Struct(strukt) => parse_struct(strukt, &attrs)?,
-		Data::Enum(inum) => parse_enum(inum, &attrs)?,
+		Data::Struct(strukt) => parse_struct(ident, strukt, &attrs)?,
+		Data::Enum(inum) => parse_enum(ident, inum, &attrs)?,
 		Data::Union(union) => parse_union(union)?
 	};
 
@@ -95,7 +95,7 @@ fn expand_openapi_type(mut input: DeriveInput) -> syn::Result<TokenStream2> {
 				// this will be used by the schema code
 				let mut dependencies = ::openapi_type::private::Dependencies::new();
 
-				let mut schema = ::openapi_type::OpenapiSchema::new(#schema_code);
+				let mut schema: ::openapi_type::OpenapiSchema = #schema_code;
 				schema.nullable = false;
 				schema.dependencies = dependencies;
 

--- a/derive/src/parser.rs
+++ b/derive/src/parser.rs
@@ -3,7 +3,7 @@ use crate::{
 	serde_derive_internals::case::RenameRule,
 	util::ToLitStr
 };
-use proc_macro2::Span;
+use proc_macro2::{Ident, Span};
 use syn::{
 	punctuated::Punctuated, spanned::Spanned as _, AngleBracketedGenericArguments, DataEnum, DataStruct, DataUnion, Fields,
 	FieldsNamed, GenericArgument, LitStr, PathArguments, Type, TypePath
@@ -22,13 +22,16 @@ pub(super) struct ParseDataField {
 
 #[allow(dead_code)]
 pub(super) enum ParseData {
-	Struct(Vec<ParseDataField>),
+	Struct {
+		name: Option<LitStr>,
+		fields: Vec<ParseDataField>
+	},
 	Enum(Vec<LitStr>),
-	Alternatives(Vec<(Option<LitStr>, ParseData)>),
+	Alternatives(Vec<ParseData>),
 	Unit
 }
 
-fn parse_named_fields(named_fields: &FieldsNamed, rename_all: Option<&LitStr>) -> syn::Result<ParseData> {
+fn parse_named_fields(named_fields: &FieldsNamed, rename_all: Option<&LitStr>) -> syn::Result<Vec<ParseDataField>> {
 	let mut fields: Vec<ParseDataField> = Vec::new();
 	for f in &named_fields.named {
 		// parse #[serde] and #[openapi] attributes
@@ -98,12 +101,18 @@ fn parse_named_fields(named_fields: &FieldsNamed, rename_all: Option<&LitStr>) -
 			ty: TypeOrInline::Type(ty)
 		});
 	}
-	Ok(ParseData::Struct(fields))
+	Ok(fields)
 }
 
-pub(super) fn parse_struct(strukt: &DataStruct, attrs: &ContainerAttributes) -> syn::Result<ParseData> {
+pub(super) fn parse_struct(ident: &Ident, strukt: &DataStruct, attrs: &ContainerAttributes) -> syn::Result<ParseData> {
 	match &strukt.fields {
-		Fields::Named(named_fields) => parse_named_fields(named_fields, attrs.rename_all.as_ref()),
+		Fields::Named(named_fields) => {
+			let fields = parse_named_fields(named_fields, attrs.rename_all.as_ref())?;
+			Ok(ParseData::Struct {
+				name: Some(ident.to_lit_str()),
+				fields
+			})
+		},
 		Fields::Unnamed(unnamed_fields) => Err(syn::Error::new(
 			unnamed_fields.span(),
 			"#[derive(OpenapiType)] does not support tuple structs"
@@ -112,7 +121,7 @@ pub(super) fn parse_struct(strukt: &DataStruct, attrs: &ContainerAttributes) -> 
 	}
 }
 
-pub(super) fn parse_enum(inum: &DataEnum, attrs: &ContainerAttributes) -> syn::Result<ParseData> {
+pub(super) fn parse_enum(ident: &Ident, inum: &DataEnum, attrs: &ContainerAttributes) -> syn::Result<ParseData> {
 	let mut strings: Vec<LitStr> = Vec::new();
 	let mut types: Vec<(LitStr, ParseData)> = Vec::new();
 
@@ -120,7 +129,12 @@ pub(super) fn parse_enum(inum: &DataEnum, attrs: &ContainerAttributes) -> syn::R
 		let name = v.ident.to_lit_str();
 		match &v.fields {
 			Fields::Named(named_fields) => {
-				types.push((name, parse_named_fields(named_fields, attrs.rename_all.as_ref())?));
+				let fields = parse_named_fields(named_fields, attrs.rename_all.as_ref())?;
+				let struct_name = format!("{}::{}", ident, name.value());
+				types.push((name, ParseData::Struct {
+					name: Some(LitStr::new(&struct_name, Span::call_site())),
+					fields
+				}));
 			},
 			Fields::Unnamed(unnamed_fields) => {
 				return Err(syn::Error::new(
@@ -139,11 +153,14 @@ pub(super) fn parse_enum(inum: &DataEnum, attrs: &ContainerAttributes) -> syn::R
 			// externally tagged (default)
 			(None, None, false) => Some(ParseData::Enum(strings)),
 			// internally tagged or adjacently tagged
-			(Some(tag), _, false) => Some(ParseData::Struct(vec![ParseDataField {
-				name: tag.clone(),
-				doc: Vec::new(),
-				ty: TypeOrInline::Inline(ParseData::Enum(strings))
-			}])),
+			(Some(tag), _, false) => Some(ParseData::Struct {
+				name: None,
+				fields: vec![ParseDataField {
+					name: tag.clone(),
+					doc: Vec::new(),
+					ty: TypeOrInline::Inline(ParseData::Enum(strings))
+				}]
+			}),
 			// untagged
 			(None, None, true) => Some(ParseData::Unit),
 			// unknown
@@ -159,17 +176,20 @@ pub(super) fn parse_enum(inum: &DataEnum, attrs: &ContainerAttributes) -> syn::R
 				types
 					.into_iter()
 					.map(|(name, mut data)| {
-						Ok((Some(name.clone()), match (&attrs.tag, &attrs.content, attrs.untagged) {
+						Ok(match (&attrs.tag, &attrs.content, attrs.untagged) {
 							// externally tagged (default)
-							(None, None, false) => ParseData::Struct(vec![ParseDataField {
-								name,
-								doc: Vec::new(),
-								ty: TypeOrInline::Inline(data)
-							}]),
+							(None, None, false) => ParseData::Struct {
+								name: None,
+								fields: vec![ParseDataField {
+									name,
+									doc: Vec::new(),
+									ty: TypeOrInline::Inline(data)
+								}]
+							},
 							// internally tagged
 							(Some(tag), None, false) => {
 								match &mut data {
-									ParseData::Struct(fields) => fields.push(ParseDataField {
+									ParseData::Struct { fields, .. } => fields.push(ParseDataField {
 										name: tag.clone(),
 										doc: Vec::new(),
 										ty: TypeOrInline::Inline(ParseData::Enum(vec![name]))
@@ -182,23 +202,26 @@ pub(super) fn parse_enum(inum: &DataEnum, attrs: &ContainerAttributes) -> syn::R
 								data
 							},
 							// adjacently tagged
-							(Some(tag), Some(content), false) => ParseData::Struct(vec![
-								ParseDataField {
-									name: tag.clone(),
-									doc: Vec::new(),
-									ty: TypeOrInline::Inline(ParseData::Enum(vec![name]))
-								},
-								ParseDataField {
-									name: content.clone(),
-									doc: Vec::new(),
-									ty: TypeOrInline::Inline(data)
-								},
-							]),
+							(Some(tag), Some(content), false) => ParseData::Struct {
+								name: None,
+								fields: vec![
+									ParseDataField {
+										name: tag.clone(),
+										doc: Vec::new(),
+										ty: TypeOrInline::Inline(ParseData::Enum(vec![name]))
+									},
+									ParseDataField {
+										name: content.clone(),
+										doc: Vec::new(),
+										ty: TypeOrInline::Inline(data)
+									},
+								]
+							},
 							// untagged
 							(None, None, true) => data,
 							// unknown
 							_ => return Err(syn::Error::new(Span::call_site(), "Unknown enum representation"))
-						}))
+						})
 					})
 					.collect::<syn::Result<Vec<_>>>()?
 			))
@@ -208,12 +231,12 @@ pub(super) fn parse_enum(inum: &DataEnum, attrs: &ContainerAttributes) -> syn::R
 		// only variants without fields
 		(Some(data), None) => Ok(data),
 		// only one variant with fields
-		(None, Some(ParseData::Alternatives(mut alt))) if alt.len() == 1 => Ok(alt.remove(0).1),
+		(None, Some(ParseData::Alternatives(mut alt))) if alt.len() == 1 => Ok(alt.remove(0)),
 		// only variants with fields
 		(None, Some(data)) => Ok(data),
 		// variants with and without fields
 		(Some(data), Some(ParseData::Alternatives(mut alt))) => {
-			alt.push((None, data));
+			alt.push(data);
 			Ok(ParseData::Alternatives(alt))
 		},
 		// no variants

--- a/tests/custom_types.rs
+++ b/tests/custom_types.rs
@@ -95,6 +95,7 @@ enum EnumWithFields {
 test_type!(EnumWithFields = {
 	"title": "EnumWithFields",
 	"oneOf": [{
+		"title": "EnumWithFields::Success",
 		"type": "object",
 		"properties": {
 			"Success": {
@@ -109,6 +110,7 @@ test_type!(EnumWithFields = {
 		},
 		"required": ["Success"]
 	}, {
+		"title": "EnumWithFields::Error",
 		"type": "object",
 		"properties": {
 			"Error": {
@@ -137,6 +139,7 @@ test_type!(EnumExternallyTagged = {
 		"type": "object",
 		"properties": {
 			"Success": {
+				"title": "EnumExternallyTagged::Success",
 				"type": "object",
 				"properties": {
 					"value": {
@@ -163,6 +166,7 @@ enum EnumInternallyTagged {
 test_type!(EnumInternallyTagged = {
 	"title": "EnumInternallyTagged",
 	"oneOf": [{
+		"title": "EnumInternallyTagged::Success",
 		"type": "object",
 		"properties": {
 			"value": {
@@ -203,6 +207,7 @@ test_type!(EnumAdjacentlyTagged = {
 				"enum": ["Success"]
 			},
 			"ct": {
+				"title": "EnumAdjacentlyTagged::Success",
 				"type": "object",
 				"properties": {
 					"value": {
@@ -235,6 +240,7 @@ enum EnumUntagged {
 test_type!(EnumUntagged = {
 	"title": "EnumUntagged",
 	"oneOf": [{
+		"title": "EnumUntagged::Success",
 		"type": "object",
 		"properties": {
 			"value": {

--- a/tests/custom_types.rs
+++ b/tests/custom_types.rs
@@ -1,20 +1,7 @@
 #![allow(dead_code)]
 use openapi_type::OpenapiType;
 
-macro_rules! test_type {
-	($ty:ty = $json:tt) => {
-		paste::paste! {
-			#[test]
-			fn [< $ty:lower >]() {
-				let schema = <$ty as OpenapiType>::schema();
-				let schema = openapi_type::OpenapiSchema::into_schema(schema);
-				let schema_json = serde_json::to_value(&schema).unwrap();
-				let expected = serde_json::json!($json);
-				pretty_assertions::assert_eq!(schema_json, expected);
-			}
-		}
-	};
-}
+include!("util/test_type.rs");
 
 #[derive(OpenapiType)]
 struct UnitStruct;
@@ -75,16 +62,21 @@ test_type!(EnumWithOneField = {
 	"title": "EnumWithOneField",
 	"properties": {
 		"Success": {
-			"type": "object",
-			"properties": {
-				"value": {
-					"type": "integer"
-				}
-			},
-			"required": ["value"]
+			"$ref": "#/components/schemas/EnumWithOneField__Success"
 		}
 	},
 	"required": ["Success"]
+}, {
+	"EnumWithOneField__Success": {
+		"title": "EnumWithOneField::Success",
+		"type": "object",
+		"properties": {
+			"value": {
+				"type": "integer"
+			}
+		},
+		"required": ["value"]
+	}
 });
 
 #[derive(OpenapiType)]
@@ -95,36 +87,43 @@ enum EnumWithFields {
 test_type!(EnumWithFields = {
 	"title": "EnumWithFields",
 	"oneOf": [{
-		"title": "EnumWithFields::Success",
 		"type": "object",
 		"properties": {
 			"Success": {
-				"type": "object",
-				"properties": {
-					"value": {
-						"type": "integer"
-					}
-				},
-				"required": ["value"]
+				"$ref": "#/components/schemas/EnumWithFields__Success"
 			}
 		},
 		"required": ["Success"]
 	}, {
-		"title": "EnumWithFields::Error",
 		"type": "object",
 		"properties": {
 			"Error": {
-				"type": "object",
-				"properties": {
-					"msg": {
-						"type": "string"
-					}
-				},
-				"required": ["msg"]
+				"$ref": "#/components/schemas/EnumWithFields__Error"
 			}
 		},
 		"required": ["Error"]
 	}]
+}, {
+	"EnumWithFields__Success": {
+		"title": "EnumWithFields::Success",
+		"type": "object",
+		"properties": {
+			"value": {
+				"type": "integer"
+			}
+		},
+		"required": ["value"]
+	},
+	"EnumWithFields__Error": {
+		"title": "EnumWithFields::Error",
+		"type": "object",
+		"properties": {
+			"msg": {
+				"type": "string"
+			}
+		},
+		"required": ["msg"]
+	}
 });
 
 #[derive(OpenapiType)]
@@ -139,14 +138,7 @@ test_type!(EnumExternallyTagged = {
 		"type": "object",
 		"properties": {
 			"Success": {
-				"title": "EnumExternallyTagged::Success",
-				"type": "object",
-				"properties": {
-					"value": {
-						"type": "integer"
-					}
-				},
-				"required": ["value"]
+				"$ref": "#/components/schemas/EnumExternallyTagged__Success"
 			}
 		},
 		"required": ["Success"]
@@ -154,6 +146,17 @@ test_type!(EnumExternallyTagged = {
 		"type": "string",
 		"enum": ["Empty", "Error"]
 	}]
+}, {
+	"EnumExternallyTagged__Success": {
+		"title": "EnumExternallyTagged::Success",
+		"type": "object",
+		"properties": {
+			"value": {
+				"type": "integer"
+			}
+		},
+		"required": ["value"]
+	}
 });
 
 #[derive(OpenapiType)]
@@ -163,6 +166,7 @@ enum EnumInternallyTagged {
 	Empty,
 	Error
 }
+// TODO the Success variant should probably be $ref-ed
 test_type!(EnumInternallyTagged = {
 	"title": "EnumInternallyTagged",
 	"oneOf": [{
@@ -207,14 +211,7 @@ test_type!(EnumAdjacentlyTagged = {
 				"enum": ["Success"]
 			},
 			"ct": {
-				"title": "EnumAdjacentlyTagged::Success",
-				"type": "object",
-				"properties": {
-					"value": {
-						"type": "integer"
-					}
-				},
-				"required": ["value"]
+				"$ref": "#/components/schemas/EnumAdjacentlyTagged__Success"
 			}
 		},
 		"required": ["ty", "ct"]
@@ -228,6 +225,17 @@ test_type!(EnumAdjacentlyTagged = {
 		},
 		"required": ["ty"]
 	}]
+}, {
+	"EnumAdjacentlyTagged__Success": {
+		"title": "EnumAdjacentlyTagged::Success",
+		"type": "object",
+		"properties": {
+			"value": {
+				"type": "integer"
+			}
+		},
+		"required": ["value"]
+	}
 });
 
 #[derive(OpenapiType)]
@@ -237,6 +245,7 @@ enum EnumUntagged {
 	Empty,
 	Error
 }
+// TODO the Success variant should probably be $ref-ed
 test_type!(EnumUntagged = {
 	"title": "EnumUntagged",
 	"oneOf": [{

--- a/tests/custom_types_attrs.rs
+++ b/tests/custom_types_attrs.rs
@@ -1,20 +1,7 @@
 #![allow(dead_code)]
 use openapi_type::OpenapiType;
 
-macro_rules! test_type {
-	($ty:ty = $json:tt) => {
-		paste::paste! {
-			#[test]
-			fn [< $ty:lower >]() {
-				let schema = <$ty as OpenapiType>::schema();
-				let schema = openapi_type::OpenapiSchema::into_schema(schema);
-				let schema_json = serde_json::to_value(&schema).unwrap();
-				let expected = serde_json::json!($json);
-				pretty_assertions::assert_eq!(schema_json, expected);
-			}
-		}
-	};
-}
+include!("util/test_type.rs");
 
 /// Very cool struct!
 #[derive(OpenapiType)]
@@ -54,14 +41,7 @@ test_type!(EnumDoc = {
 		"type": "object",
 		"properties": {
 			"Message": {
-				"type": "object",
-				"properties": {
-					"text": {
-						"type": "string",
-						"description": "The text of the message in markdown format."
-					}
-				},
-				"required": ["text"]
+				"$ref": "#/components/schemas/EnumDoc__Message"
 			}
 		},
 		"required": ["Message"]
@@ -69,6 +49,18 @@ test_type!(EnumDoc = {
 		"type": "string",
 		"enum": ["Error"]
 	}]
+}, {
+	"EnumDoc__Message": {
+		"title": "EnumDoc::Message",
+		"type": "object",
+		"properties": {
+			"text": {
+				"type": "string",
+				"description": "The text of the message in markdown format."
+			}
+		},
+		"required": ["text"]
+	}
 });
 
 #[derive(OpenapiType)]

--- a/tests/util/test_type.rs
+++ b/tests/util/test_type.rs
@@ -1,0 +1,30 @@
+macro_rules! test_type {
+	($ty:ty = $json:tt) => {
+		paste::paste! {
+			#[test]
+			fn [< $ty:lower >]() {
+				let schema = <$ty as OpenapiType>::schema();
+				let schema = openapi_type::OpenapiSchema::into_schema(schema);
+				let schema_json = serde_json::to_value(&schema).unwrap();
+				let expected = serde_json::json!($json);
+				pretty_assertions::assert_eq!(schema_json, expected);
+			}
+		}
+	};
+	($ty:ty = $json:tt, {$($dep_name:literal: $dep_json:tt),*}) => {
+		test_type!($ty = $json);
+		paste::paste! {
+			#[test]
+			fn [< $ty:lower _dependencies >]() {
+				let mut schema = <$ty as OpenapiType>::schema();
+				$({
+					let dep_schema = schema.dependencies.remove($dep_name).expect(concat!("Schema is missing the following dependency: ", $dep_name));
+					let dep_schema = openapi_type::OpenapiSchema::into_schema(dep_schema);
+					let dep_json = serde_json::to_value(&dep_schema).unwrap();
+					let expected = serde_json::json!($dep_json);
+					pretty_assertions::assert_eq!(dep_json, expected)
+				})*
+			}
+		}
+	};
+}


### PR DESCRIPTION
The objects representing enum variants now have a title of the form `EnumIdent::VariantIdent`. This means that tooling can use better names than `EnumIdentOneOf1` for the variants. Also, this has the side effect of them being mostly `$ref`-ed now instead of inlined, which is good because if we were ever to use the `discriminator` property, this is required.