### PR TITLE
Revert "$ref-erence all non-trivial oneOf objects"

### DIFF
--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -117,7 +117,6 @@ fn gen_enum(variants: &[LitStr]) -> TokenStream {
 fn gen_alt(alt: &[ParseData]) -> TokenStream {
 	let openapi = path!(::openapi_type::openapi);
 	let schema = alt.iter().map(|data| data.gen_schema());
-	let index = alt.iter().enumerate().map(|(i, _)| i);
 	quote! {
 		{
 			let mut alternatives = <::std::vec::Vec<
@@ -125,24 +124,7 @@ fn gen_alt(alt: &[ParseData]) -> TokenStream {
 			>>::new();
 			#(alternatives.push({
 				let alt_schema = #schema;
-				let alt_prop_len = match &alt_schema.schema {
-					#openapi::SchemaKind::Type(#openapi::Type::Object(obj)) => obj.properties.len(),
-					_ => 0
-				};
-				// $ref-erence all non-trivial objects
-				if alt_prop_len > 0 {
-					::openapi_type::private::reference(
-						&mut dependencies,
-						alt_schema,
-						|| ::std::format!("{}_oneOf_{}", NAME, #index)
-					)
-				} else {
-					::openapi_type::private::inline_if_unnamed(
-						&mut dependencies,
-						alt_schema,
-						None
-					)
-				}
+				::openapi_type::private::inline_if_unnamed(&mut dependencies, alt_schema, None)
 			});)*
 
 			::openapi_type::OpenapiSchema::new(

--- a/src/private.rs
+++ b/src/private.rs
@@ -12,37 +12,22 @@ fn add_dependencies(dependencies: &mut Dependencies, other: &mut Dependencies) {
 	}
 }
 
-/// Add the schema to the dependencies and always return a reference. The schema's dependencies
-/// are always added to the dependencies.
-pub fn reference<T, F>(dependencies: &mut Dependencies, mut schema: OpenapiSchema, fallback_ref_name: F) -> ReferenceOr<T>
-where
-	F: FnOnce() -> String
-{
-	add_dependencies(dependencies, &mut schema.dependencies);
-
-	let ref_name = schema
-		.name
-		.as_deref()
-		.map(|name| name.replace(|c: char| !c.is_alphanumeric(), "_"))
-		.unwrap_or_else(fallback_ref_name);
-	let reference = format!("#/components/schemas/{}", ref_name);
-
-	dependencies.insert(ref_name, schema);
-	ReferenceOr::Reference { reference }
-}
-
-/// Inline the schema if it is unnamed, otherwise return a reference to it and add it to the
-/// dependencies. The schema's dependencies are always added to the dependencies.
 pub fn inline_if_unnamed(
 	dependencies: &mut Dependencies,
 	mut schema: OpenapiSchema,
 	doc: Option<&'static str>
 ) -> ReferenceOr<Schema> {
-	match &schema.name {
-		Some(_) => reference(dependencies, schema, || unreachable!()),
+	add_dependencies(dependencies, &mut schema.dependencies);
+	match schema.name.as_ref() {
+		Some(schema_name) => {
+			let ref_name = schema_name.replace(|c: char| !c.is_alphanumeric(), "_");
+			let mut reference = "#/components/schemas/".to_string();
+			reference.push_str(&ref_name);
+			dependencies.insert(ref_name, schema);
+			ReferenceOr::Reference { reference }
+		},
 
 		None => {
-			add_dependencies(dependencies, &mut schema.dependencies);
 			let mut schema = schema.into_schema();
 			if let Some(doc) = doc {
 				schema.schema_data.description = Some(doc.to_string());

--- a/tests/custom_types.rs
+++ b/tests/custom_types.rs
@@ -184,7 +184,14 @@ test_type!(EnumInternallyTagged = {
 	"oneOf": [{
 		"$ref": "#/components/schemas/EnumInternallyTagged__Success"
 	}, {
-		"$ref": "#/components/schemas/EnumInternallyTagged_oneOf_1"
+		"type": "object",
+		"properties": {
+			"ty": {
+				"type": "string",
+				"enum": ["Empty", "Error"]
+			}
+		},
+		"required": ["ty"]
 	}]
 }, {
 	"EnumInternallyTagged__Success": {
@@ -200,16 +207,6 @@ test_type!(EnumInternallyTagged = {
 			}
 		},
 		"required": ["value", "ty"]
-	},
-	"EnumInternallyTagged_oneOf_1": {
-		"type": "object",
-		"properties": {
-			"ty": {
-				"type": "string",
-				"enum": ["Empty", "Error"]
-			}
-		},
-		"required": ["ty"]
 	}
 });
 
@@ -225,7 +222,14 @@ test_type!(EnumAdjacentlyTagged = {
 	"oneOf": [{
 		"$ref": "#/components/schemas/EnumAdjacentlyTagged__Success__AdjTagWrapper"
 	}, {
-		"$ref": "#/components/schemas/EnumAdjacentlyTagged_oneOf_1"
+		"type": "object",
+		"properties": {
+			"ty": {
+				"type": "string",
+				"enum": ["Empty", "Error"]
+			}
+		},
+		"required": ["ty"]
 	}]
 }, {
 	"EnumAdjacentlyTagged__Success": {
@@ -251,16 +255,6 @@ test_type!(EnumAdjacentlyTagged = {
 			}
 		},
 		"required": ["ty", "ct"]
-	},
-	"EnumAdjacentlyTagged_oneOf_1": {
-		"type": "object",
-		"properties": {
-			"ty": {
-				"type": "string",
-				"enum": ["Empty", "Error"]
-			}
-		},
-		"required": ["ty"]
 	}
 });
 


### PR DESCRIPTION
Reverts #12 because I chose not to implement #10, so that change is no longer neccessary.